### PR TITLE
fix: 上と下の表示調整

### DIFF
--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -11,7 +11,7 @@ export function Root() {
     ];
 
     return (
-        <div className="h-screen flex flex-col">
+        <div className="flex flex-col" style={{ height: '100dvh' }}>
             {/* Header - Fixed height */}
             <Header />
             

--- a/src/index.css
+++ b/src/index.css
@@ -4,8 +4,10 @@
 
 html, body, #root {
   height: 100%;
+  height: 100dvh;
   margin: 0;
   padding: 0;
+  overflow: hidden;
 }
 
 :root {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-})


### PR DESCRIPTION
- Issue Link: #8 

## 背景
- 画面UIのズレにより縦方向にのスクロールが必要になっていた, これは漫画アプリのようなUIを目指すうえでノイズをである

## やったこと
  1. Root.tsx: 100dvh（Dynamic Viewport Height）使用
  2. index.css:
    - html, body, #rootにも100dvh追加
    - overflow: hiddenでスクロールを防止

  100dvhの効果：
  - スマホブラウザのアドレスバーやUIバーの表示/非表示に自動対応
  - 実際に見える画面領域にぴったり合わせる
  - iOS Safari、Android Chromeの動的UIに対応

## 動作確認手順
make dev によるサーバー起動
ngrokでportフォワード
スマホで表示