### PR TITLE
fix: preventdefultを削除

### DIFF
--- a/src/hooks/useTouchNavigation.ts
+++ b/src/hooks/useTouchNavigation.ts
@@ -43,7 +43,6 @@ export function useTouchNavigation(pages: PageInfo[], currentPath: string) {
     
     // 水平方向のドラッグかどうか判定
     if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 10) {
-      event.preventDefault(); // スクロールを防ぐ
       
       const screenWidth = window.innerWidth;
       const maxDragDistance = screenWidth * 0.8; // 最大ドラッグ距離


### PR DESCRIPTION
- Issue Link: #20 

## 背景
- preventdefultを縦スクロール防止の為に導入していた
- preventdefultが横スクロールの際にエラーを履いていた

## やったこと
- preventdefultを削除
  - これを削除しても、画面サイズが表示領域ぴったりなので縦スクロールは発生しないはず


## 動作確認手順
make dev 
dev tools のconsole見る
スライド操作をしてみる
