### PR TITLE
feat: shadcnのcarouselによるページ遷移の実装

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,31 +1,12 @@
-import { createBrowserRouter, RouterProvider, Navigate } from "react-router";
+import { BrowserRouter } from "react-router";
 import { Root } from '../app/Root'
-import { Home } from '../pages/Home';
-import { About } from '../pages/About';
 
 function App() {
-  const router = createBrowserRouter([
-    {
-      path: "/",
-      element: <Root />,
-      children: [
-        {
-          index: true,
-          element: <Navigate to="/home" replace />
-        },
-        {
-          path: "home",
-          element: <Home />
-        },
-        {
-          path: "about",
-          element: <About />
-        }
-      ]
-    },
-  ]);
-
-  return <RouterProvider router={router} />;
+  return (
+    <BrowserRouter>
+      <Root />
+    </BrowserRouter>
+  );
 }
 
 export default App

--- a/src/app/Root.tsx
+++ b/src/app/Root.tsx
@@ -1,26 +1,23 @@
 import { Header } from '../components/Header'
 import { Footer } from '../components/Footer';
-import { Outlet, useLocation } from 'react-router';
-import { useTouchNavigation } from '../hooks/useTouchNavigation';
+import { CarouselRouter } from '../components/CarouselRouter';
+import { Home } from '../pages/Home';
+import { About } from '../pages/About';
+
+
 
 import type { PageInfo } from '../types/navigation';
 
 export function Root() {
+    const routes = [
+        { path: '/about', element: <About /> },
+        { path: '/home', element: <Home /> }
+    ];
+
     const pages: PageInfo[] = [
         { path: '/home', name: 'ホーム' },
         { path: '/about', name: '概要' }
     ];
-
-    const location = useLocation();
-    const { 
-        handleTouchStart, 
-        handleTouchMove, 
-        handleTouchEnd, 
-        dragOffset, 
-        isDragging,
-        nextPage,
-        prevPage 
-    } = useTouchNavigation(pages, location.pathname);
 
     return (
         <div 
@@ -34,65 +31,9 @@ export function Root() {
             {/* Header - Fixed height */}
             <Header />
             
-            {/* Main content area with touch navigation */}
-            <main 
-                className="relative flex-1 bg-gray-100 overflow-hidden"
-                onTouchStart={handleTouchStart}
-                onTouchMove={handleTouchMove}
-                onTouchEnd={handleTouchEnd}
-                style={{
-                    touchAction: 'pan-x pinch-zoom',
-                    overscrollBehavior: 'none'
-                }}
-            >
-                {/* Current Page */}
-                <div 
-                    className="absolute inset-0 p-4 sm:p-6 lg:p-8"
-                    style={{
-                        transform: `translateX(${dragOffset}px)`,
-                        transition: isDragging ? 'none' : 'transform 200ms ease-out'
-                    }}
-                >
-                    <div className="h-full">
-                        <Outlet />
-                    </div>
-                </div>
-
-                {/* Next Page Preview (右側から左へ) */}
-                {nextPage && dragOffset > 0 && (
-                    <div 
-                        className="absolute inset-0 bg-gray-100 p-4 sm:p-6 lg:p-8"
-                        style={{
-                            transform: `translateX(${dragOffset - window.innerWidth}px)`,
-                            transition: isDragging ? 'none' : 'transform 200ms ease-out'
-                        }}
-                    >
-                        <div className="h-full flex items-center justify-center">
-                            <div className="text-center">
-                                <h1 className="text-3xl font-bold text-gray-900">{nextPage.name}</h1>
-                                <p className="mt-4 text-gray-600">次のページ</p>
-                            </div>
-                        </div>
-                    </div>
-                )}
-
-                {/* Previous Page Preview (左側から右へ) */}
-                {prevPage && dragOffset < 0 && (
-                    <div 
-                        className="absolute inset-0 bg-gray-100 p-4 sm:p-6 lg:p-8"
-                        style={{
-                            transform: `translateX(${dragOffset + window.innerWidth}px)`,
-                            transition: isDragging ? 'none' : 'transform 200ms ease-out'
-                        }}
-                    >
-                        <div className="h-full flex items-center justify-center">
-                            <div className="text-center">
-                                <h1 className="text-3xl font-bold text-gray-900">{prevPage.name}</h1>
-                                <p className="mt-4 text-gray-600">前のページ</p>
-                            </div>
-                        </div>
-                    </div>
-                )}
+            {/* Carousel-based page navigation */}
+            <main className="flex-1 overflow-hidden">
+                <CarouselRouter routes={routes} />
             </main>
             
             {/* Footer - Fixed at bottom */}

--- a/src/components/CarouselRouter.tsx
+++ b/src/components/CarouselRouter.tsx
@@ -1,0 +1,83 @@
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { Carousel, CarouselContent, CarouselItem, type CarouselApi } from './ui/carousel';
+
+interface Route {
+  path: string;
+  element: React.ReactNode;
+}
+
+interface CarouselRouterProps {
+  routes: Route[];
+}
+
+export function CarouselRouter({ routes }: CarouselRouterProps) {
+  const location = useLocation(); // 現在のURL情報（/home, /aboutなど）
+  const navigate = useNavigate(); // URLを変更する関数
+  const [api, setApi] = useState<CarouselApi>(); // Carouselの制御API
+  const [currentIndex, setCurrentIndex] = useState(0); // 現在表示中のスライドインデックス
+  
+  // URLからスライドのインデックスを計算する関数
+  const getCurrentIndex = () => {
+    const currentRoute = routes.findIndex(route => route.path === location.pathname);
+    return currentRoute >= 0 ? currentRoute : 0;
+  };
+
+  // 【パターン1】URL変更 → Carouselアニメーション
+  // ブラウザの戻る/進むボタンやURL直接入力で発生
+  useEffect(() => {
+    if (!api) return; // Carouselがまだ初期化されていない場合は何もしない
+    
+    const newIndex = getCurrentIndex(); // 新しいURLに対応するスライド番号を取得
+    if (newIndex !== currentIndex) { // 現在のスライドと違う場合のみ実行
+      setCurrentIndex(newIndex); // state更新
+      api.scrollTo(newIndex); // 🎯 ここで滑らかなアニメーションが発生！
+    }
+  }, [location.pathname, api, currentIndex]); // location.pathname（URL）が変わったときに実行
+
+  // 【パターン2】Carouselスワイプ → URL更新
+  // ユーザーが画面をスワイプしたときに発生
+  useEffect(() => {
+    if (!api) return;
+
+    const onSelect = () => {
+      const selectedIndex = api.selectedScrollSnap(); // スワイプ後のスライド番号を取得
+      if (selectedIndex !== currentIndex) { // 現在と違う場合のみ実行
+        setCurrentIndex(selectedIndex); // state更新
+        const targetPath = routes[selectedIndex]?.path; // スライド番号からURLを取得
+        if (targetPath) {
+          navigate(targetPath, { replace: true }); // 🌐 URLを更新（ブラウザのアドレスバーが変わる）
+        }
+      }
+    };
+
+    // スライド変更イベントを監視
+    api.on('select', onSelect); // Carouselがスライドするたびに onSelect が呼ばれる
+    return () => api.off('select', onSelect); // コンポーネント削除時にイベントを削除
+  }, [api, currentIndex, navigate, routes]);
+
+  return (
+    <div className="h-screen w-screen overflow-hidden">
+      <Carousel
+        setApi={setApi}
+        className="h-full w-full"
+        opts={{
+          align: 'start',
+          loop: false,
+          skipSnaps: false,
+          dragFree: false,
+        }}
+      >
+        <CarouselContent className="h-full">
+          {routes.map((route, index) => (
+            <CarouselItem key={route.path} className="h-full w-full flex-shrink-0">
+              <div className="h-full w-full p-4 sm:p-6 lg:p-8">
+                {route.element}
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+      </Carousel>
+    </div>
+  );
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,260 @@
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    )
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+    const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) {
+        return
+      }
+
+      setCanScrollPrev(api.canScrollPrev())
+      setCanScrollNext(api.canScrollNext())
+    }, [])
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev()
+    }, [api])
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext()
+    }, [api])
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault()
+          scrollPrev()
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault()
+          scrollNext()
+        }
+      },
+      [scrollPrev, scrollNext]
+    )
+
+    React.useEffect(() => {
+      if (!api || !setApi) {
+        return
+      }
+
+      setApi(api)
+    }, [api, setApi])
+
+    React.useEffect(() => {
+      if (!api) {
+        return
+      }
+
+      onSelect(api)
+      api.on("reInit", onSelect)
+      api.on("select", onSelect)
+
+      return () => {
+        api?.off("select", onSelect)
+      }
+    }, [api, onSelect])
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api: api,
+          opts,
+          orientation:
+            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    )
+  }
+)
+Carousel.displayName = "Carousel"
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+})
+CarouselContent.displayName = "CarouselContent"
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+CarouselItem.displayName = "CarouselItem"
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute  h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-left-12 top-1/2 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+})
+CarouselPrevious.displayName = "CarouselPrevious"
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full",
+        orientation === "horizontal"
+          ? "-right-12 top-1/2 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+})
+CarouselNext.displayName = "CarouselNext"
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
- Issue Link: #27 

## 背景
ページ遷移のスクロールアニメーションを漫画アプリジャンプ+をイメージしていた.
しかしそれができていなかった


## やったこと
- ページ遷移をshadcnのcarouselに対応
- urlとページ遷移を同期するために, useEffectを使用


## 動作確認手順
make dev
ngrok
スマホで確認
