### PR TITLE
fix: タッチの範囲を画面の描写領域全体に適用

### DIFF
--- a/src/components/CarouselRouter.tsx
+++ b/src/components/CarouselRouter.tsx
@@ -70,7 +70,7 @@ export function CarouselRouter({ routes }: CarouselRouterProps) {
       >
         <CarouselContent className="h-full">
           {routes.map((route, index) => (
-            <CarouselItem key={route.path} className="h-full w-full flex-shrink-0">
+            <CarouselItem key={route.path} className="h-full w-full flex-shrink-0 pl-0">
               <div className="h-full w-full p-4 sm:p-6 lg:p-8">
                 {route.element}
               </div>

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -155,12 +155,16 @@ const CarouselContent = React.forwardRef<
   const { carouselRef, orientation } = useCarousel()
 
   return (
-    <div ref={carouselRef} className="overflow-hidden">
+    <div 
+      ref={carouselRef} 
+      className="overflow-hidden h-full w-full"
+      style={{ touchAction: 'pan-x' }}
+    >
       <div
         ref={ref}
         className={cn(
-          "flex",
-          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          "flex h-full",
+          orientation === "horizontal" ? "" : "flex-col",
           className
         )}
         {...props}
@@ -182,8 +186,7 @@ const CarouselItem = React.forwardRef<
       role="group"
       aria-roledescription="slide"
       className={cn(
-        "min-w-0 shrink-0 grow-0 basis-full",
-        orientation === "horizontal" ? "pl-4" : "pt-4",
+        "min-w-0 shrink-0 grow-0 basis-full h-full",
         className
       )}
       {...props}


### PR DESCRIPTION
- Issue Link: #33  

## 背景
ジャンプ+のように画面全体でスクロール判定が欲しかった
しかし, それがうまくできていなかった


## やったこと
  1. CarouselItemのpadding削除: pl-0を追加してデフォルトのpaddingを無効化
  2. CarouselContentの拡張: h-full w-fullを追加し、touchAction: 'pan-x'で水平スワイプを明示的に許可
  3. 負のマージン削除: CarouselContentの-ml-4を削除してレイアウトを調整
  4. CarouselItemの高さ指定: h-fullを追加して縦方向いっぱいに表示



## 動作確認手順
make dev 
ngrok 
スマホでスクロール確認
