### PR TITLE
fix: 本棚ページのみ縦スクロール可能に変更

### DIFF
--- a/src/pages/Bookshelf.tsx
+++ b/src/pages/Bookshelf.tsx
@@ -24,7 +24,7 @@ export function Bookshelf() {
   };
 
   return (
-    <div className="h-full w-full p-8">
+    <div className="h-full w-full p-8 overflow-y-auto">
       <h1 className="text-3xl font-bold text-center mb-8">本棚</h1>
       
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 max-w-4xl mx-auto">


### PR DESCRIPTION
- Issue Link: #59 

## 背景
本棚に本が増えたとき、画像が見切れてしまっていた。 

## やったこと
本棚ページの縦スクロールを可能にした 

## 動作確認手順
本棚ページの閲覧と、そのスクロールが可能かのチェック 