### PR TITLE
chore: .copilotディレクトリをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.mcp.json
 *.serena
 
+# Copilot custom prompts (user-specific configuration)
+.copilot/
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
## 概要
- ユーザー固有のCopilot設定ファイルを追跡対象外に設定

## 変更理由
- `.copilot/prompts` ディレクトリはユーザー固有のカスタムプロンプト設定を含むため、各開発者の環境ごとに異なる内容となる
- バージョン管理の対象外とすることで、不要なコンフリクトを防ぐ

## 動作確認手順
- `.copilot/` ディレクトリが git status で表示されないことを確認
