### PR TITLE
chore: Vercel設定ファイルを削除

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-  "buildCommand": "cd ui && npm run build",
-  "outputDirectory": "ui/dist",
-  "installCommand": "cd ui && npm install",
-  "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
-  ]
-}
-


### PR DESCRIPTION
## 概要
- Vercelへのデプロイを使用しないため、vercel.jsonを削除

## 変更理由
- プロジェクトではCloudflare Pagesを使用しているため、Vercel設定ファイルは不要

## 動作確認手順
- ビルドが正常に動作することを確認