### PR TITLE
fix: #126 Google OAuth認証のリダイレクト処理を改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "yamadai-manken-home",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
         "class-variance-authority": "^0.7.1",

--- a/ui/src/lib/supabase.ts
+++ b/ui/src/lib/supabase.ts
@@ -22,9 +22,28 @@ if (typeof supabaseUrl !== 'string' || typeof supabaseAnonKey !== 'string' || !s
   );
 }
 
+// URLの形式を検証（基本的なチェック）
+try {
+  const url = new URL(supabaseUrl);
+  if (!url.hostname.includes('supabase')) {
+    if (import.meta.env.DEV) {
+      console.warn('警告: Supabase URLの形式が通常と異なります');
+    }
+  }
+} catch {
+  throw new Error('Supabase URLの形式が不正です');
+}
+
 /**
  * Supabaseクライアントのインスタンス
  *
  * このインスタンスはアプリケーション全体で共有される。
  */
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    flowType: 'pkce',
+    detectSessionInUrl: true,
+    persistSession: true,
+    autoRefreshToken: true,
+  },
+});

--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -31,6 +31,7 @@ export function Login() {
         provider: 'google',
         options: {
           redirectTo: `${window.location.origin}/`,
+          skipBrowserRedirect: false,
         },
       });
 
@@ -41,12 +42,11 @@ export function Login() {
       // OAuth処理が開始されると自動的にリダイレクトされるため、
       // ここでの処理は不要
     } catch (err) {
-      console.error('ログインエラー:', err);
-      setError(
-        err instanceof Error
-          ? err.message
-          : 'ログインに失敗しました。もう一度お試しください。'
-      );
+      if (import.meta.env.DEV) {
+        console.error('ログインエラー:', err);
+      }
+      // セキュリティのため、詳細なエラーメッセージは表示しない
+      setError('ログインに失敗しました。もう一度お試しください。');
       setIsLoading(false);
     }
   };

--- a/ui/src/stores/authStore.ts
+++ b/ui/src/stores/authStore.ts
@@ -23,6 +23,8 @@ interface AuthState {
   isLoading: boolean;
   /** 認証済みかどうか */
   isAuthenticated: boolean;
+  /** 認証エラー情報 */
+  authError: { code: string; description: string } | null;
 
   /**
    * ユーザーとセッションを設定する
@@ -34,6 +36,11 @@ interface AuthState {
    * ログアウト処理を実行する
    */
   signOut: () => Promise<void>;
+
+  /**
+   * エラーをクリアする
+   */
+  clearError: () => void;
 }
 
 /**
@@ -49,6 +56,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   session: null,
   isLoading: true,
   isAuthenticated: false,
+  authError: null,
 
   setSession: (session) => {
     set({
@@ -70,11 +78,16 @@ export const useAuthStore = create<AuthState>((set) => ({
         user: null,
         session: null,
         isAuthenticated: false,
+        authError: null,
       });
     } catch (error) {
       console.error('ログアウト処理中にエラーが発生しました:', error);
       throw error;
     }
+  },
+
+  clearError: () => {
+    set({ authError: null });
   },
 }));
 
@@ -84,7 +97,51 @@ export const useAuthStore = create<AuthState>((set) => ({
  */
 void (async () => {
   try {
-    // 既存のセッションを取得
+    // URLからエラーパラメータをチェック
+    const url = new URL(window.location.href);
+    const errorCode = url.searchParams.get('error_code') || url.hash.match(/error_code=([^&]+)/)?.[1];
+    const errorDescription = url.searchParams.get('error_description') || url.hash.match(/error_description=([^&]+)/)?.[1];
+    
+    if (errorCode) {
+      const decodedDescription = errorDescription ? decodeURIComponent(errorDescription.replace(/\+/g, ' ')) : '';
+      useAuthStore.setState({
+        authError: {
+          code: errorCode,
+          description: decodedDescription,
+        },
+      });
+      
+      // URLからエラーパラメータをクリーンアップ
+      url.searchParams.delete('error');
+      url.searchParams.delete('error_code');
+      url.searchParams.delete('error_description');
+      url.hash = '';
+      window.history.replaceState({}, '', url.pathname);
+    }
+
+    // 認証状態の変更を監視（これを先に設定）
+    supabase.auth.onAuthStateChange((_event, session) => {
+      if (import.meta.env.DEV) {
+        console.log('Auth state changed:', _event, session?.user?.email);
+      }
+      useAuthStore.setState({
+        session,
+        user: session?.user ?? null,
+        isAuthenticated: !!session,
+        isLoading: false,
+      });
+
+      // 認証成功後、URLのcodeパラメータをクリーンアップ
+      if (_event === 'SIGNED_IN' && session) {
+        const url = new URL(window.location.href);
+        if (url.searchParams.has('code')) {
+          url.searchParams.delete('code');
+          window.history.replaceState({}, '', url.toString());
+        }
+      }
+    });
+
+    // 既存のセッションを取得（PKCEコード交換も自動的に実行される）
     const {data, error} = await supabase.auth.getSession();
 
     if (error) {
@@ -93,21 +150,15 @@ void (async () => {
       return;
     }
 
+    if (import.meta.env.DEV) {
+      console.log('Session retrieved:', data.session?.user?.email);
+    }
+    
     useAuthStore.setState({
       session: data.session,
       user: data.session?.user ?? null,
       isAuthenticated: !!data.session,
       isLoading: false,
-    });
-
-    // 認証状態の変更を監視
-    supabase.auth.onAuthStateChange((_event, session) => {
-      useAuthStore.setState({
-        session,
-        user: session?.user ?? null,
-        isAuthenticated: !!session,
-        isLoading: false,
-      });
     });
   } catch (error) {
     console.error('認証の初期化に失敗しました:', error);


### PR DESCRIPTION
- Issue Link: #126

## 概要
Google OAuth認証におけるリダイレクト処理の問題を修正し、PKCEフローを導入してセキュリティと信頼性を向上させました。

## 変更内容

### 1. Supabase認証設定の改善
- PKCEフロー(Proof Key for Code Exchange)を有効化
- URL内のセッション情報を自動検出する設定を追加
- セッション永続化とトークン自動更新を有効化
- Supabase URL形式のバリデーションを追加

### 2. ログインエラーハンドリングの改善
- エラーログを開発環境のみに制限
- セキュリティ向上のため汎用的なエラーメッセージを表示
- リダイレクトオプションを明示的に設定

### 3. 認証ストアの機能拡張
- エラーステート管理機能を追加（authError）
- URLからのエラーパラメータを自動検出・クリーンアップ
- 認証状態監視の順序を改善（リダイレクト処理の確実化）
- 認証成功後のcodeパラメータをクリーンアップ
- 開発環境でのデバッグログを追加

## 変更理由
Google OAuth認証後のリダイレクト処理において、認証コードの交換が適切に行われない問題が発生していました。PKCEフローを導入することで、より安全で信頼性の高い認証フローを実現します。

## 動作確認手順
1. ログインページにアクセス
2. 「Googleでログイン」ボタンをクリック
3. Googleの認証画面で認証を完了
4. トップページにリダイレクトされ、ログイン状態が維持されることを確認
5. エラーが発生した場合、適切なエラーメッセージが表示されることを確認
