### PR TITLE
redirect to を削除

### DIFF
--- a/ui/src/pages/Login.tsx
+++ b/ui/src/pages/Login.tsx
@@ -29,11 +29,8 @@ export function Login() {
       // Supabase AuthのGoogle OAuthログインを実行
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
-        options: {
-          redirectTo: `${window.location.origin}/`,
-          skipBrowserRedirect: false,
-        },
       });
+
 
       if (error) {
         throw error;


### PR DESCRIPTION
Issue Link:

## 概要
- ui/src/pages/Login.tsx の Supabase OAuth 呼び出しから未使用の `options.redirectTo` と `skipBrowserRedirect` を削除

## 変更理由
- 未使用/不要なオプションの除去

## 動作確認手順
- ログインページでGoogleログインをクリックし、リダイレクトされることを確認
